### PR TITLE
fixed unusual behaviour of barre chords

### DIFF
--- a/app/src/main/java/com/github/airsaid/chordview/MainActivity.java
+++ b/app/src/main/java/com/github/airsaid/chordview/MainActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.RadioGroup;
+
 import com.github.airsaid.library.widget.Chord;
 import com.github.airsaid.library.widget.ChordView;
 
@@ -12,9 +13,9 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements RadioGroup.OnCheckedChangeListener {
 
-    private ChordView   mChordView;
+    private ChordView mChordView;
     private List<Chord> mChords;
-    private int         mIndex;
+    private int mIndex;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -35,6 +36,7 @@ public class MainActivity extends AppCompatActivity implements RadioGroup.OnChec
         mChords.add(new Chord(new int[]{-1, 3, 4, 2, 4, 2}, new int[]{0, 2, 3, 1, 4, 1}));
         mChords.add(new Chord(new int[]{-1, 3, 2, 0, 1, 0}));
         mChords.add(new Chord(new int[]{3, 3, 5, 5, 5, 3}));
+        mChords.add(new Chord(new int[]{3, -1, 0, 0, 3, 3},new int[]{2,0,0,0,3,4}));
         mChordView.setChord(mChords.get(mIndex));
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 09 18:30:30 CST 2018
+#Mon Mar 25 15:54:13 GMT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/library/src/main/java/com/github/airsaid/library/widget/ChordHelper.java
+++ b/library/src/main/java/com/github/airsaid/library/widget/ChordHelper.java
@@ -81,8 +81,17 @@ public class ChordHelper {
     public int getWithFirstString(Chord chord) {
         int string = 1;
         int[] frets = chord.getFrets();
+        int[] fingers = chord.getFingers();
         while (frets[frets.length - 1] == frets[frets.length - 1 - string]) {
-            string += 1;
+            if(fingers!=null){
+                if(fingers[fingers.length-1]== fingers[fingers.length-1-string]){
+                    string+=1;
+                }
+                return string;
+            }else{
+                string += 1;
+            }
+
         }
         return string;
     }


### PR DESCRIPTION
I was using the library in my project and realized that an unusual barre chord was displayed despite the fact that I specified different fingers for the notes. 

This is the code I wrote:
`chordView.setChord(new  Chord(new int[]{3, -1, 0, 0, 3, 3}, new int[]{2, 0, 0, 0, 3, 4}));` 

Below is the chord that was displayed initially verses after the fix

### Before
![device-2019-03-25-171523](https://user-images.githubusercontent.com/2436062/54940283-5a102280-4f22-11e9-8dd3-8e526d93581b.png)

### After
![device-2019-03-25-171257](https://user-images.githubusercontent.com/2436062/54940128-03a2e400-4f22-11e9-8c2d-1c2969bb43f5.png)

Thanks for having a look at it. I would love to make more contributions to the project
